### PR TITLE
Remove hardcoded private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Run the application:
 mvn spring-boot:run
 ```
 
+The application expects a private key for blockchain operations. Provide it via the `web3.private-key` property or as an environment variable:
+
+```bash
+export WEB3_PRIVATE_KEY=your_main_wallet_key
+mvn spring-boot:run -Dweb3.private-key=$WEB3_PRIVATE_KEY
+```
+
 ### Solidity Contracts
 
 The contracts are located in the `contracts/` directory. Compile and deploy them via Remix IDE or Hardhat.

--- a/blockbank/src/main/java/com/blockbank/blockbank/service/impl/Web3ServiceImpl.java
+++ b/blockbank/src/main/java/com/blockbank/blockbank/service/impl/Web3ServiceImpl.java
@@ -3,6 +3,7 @@ package com.blockbank.blockbank.service.impl;
 import com.blockbank.blockbank.blockchain.contract.SwapMock;
 import com.blockbank.blockbank.service.Web3Service;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.web3j.protocol.Web3j;
 import org.web3j.tx.gas.DefaultGasProvider;
@@ -19,8 +20,9 @@ public class Web3ServiceImpl implements Web3Service {
 
     private final Web3j web3j;
 
-    // Geliştirme amaçlı basit private key – gerçekte env ile alınmalı
-    private static final String PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    // Private key injected from configuration
+    @Value("${web3.private-key}")
+    private String privateKey;
 
     // Kontrat adresi deploy.js çıktısında loglanmıştı
     private static final String CONTRACT_ADDRESS = "0x5FbDB2315678afecb367f032d93F642f64180aa3";
@@ -33,7 +35,7 @@ public class Web3ServiceImpl implements Web3Service {
     @Override
     public String performSwap(String ethAddress, BigDecimal amount, String fromToken, String toToken) {
         try {
-            Credentials credentials = Credentials.create(PRIVATE_KEY);
+            Credentials credentials = Credentials.create(privateKey);
             RawTransactionManager txManager = new RawTransactionManager(web3j, credentials);
             DefaultGasProvider gasProvider = new DefaultGasProvider();
 

--- a/blockbank/src/main/resources/application.properties
+++ b/blockbank/src/main/resources/application.properties
@@ -19,6 +19,7 @@ logging.level.org.springframework.security=DEBUG
 jwt.secret=YOUR_JWT_SECRET
 
 web3.rpc-url=YOUR_ALCHEMY_API_KEY
+# Inject via environment variable or command line
 web3.private-key=MAIN_WALLET_PRIVATE_KEY
 web3.wallet.address=0xMAIN_WALLET_ADDRESS
 aes.key=YOUR_AES_KEY


### PR DESCRIPTION
## Summary
- load private key via `@Value` in `Web3ServiceImpl`
- document how to supply the private key when running the app
- clarify in `application.properties` that the property should be provided externally

## Testing
- `mvn test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_683f7ceedd7c833195f8a6fa9a5c8797